### PR TITLE
feat: chatgpt 공지 요약 후크 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "@slack/bolt": "^3.12.2",
     "@slack/web-api": "^6.8.1",
-    "chatgpt": "^5.0.10",
+    "chatgpt": "^5.1.1",
     "dotenv": "^16.0.3",
+    "outdent": "^0.8.0",
+    "promise-all-properties": "^3.0.6",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,8 +3,10 @@ lockfileVersion: 5.4
 specifiers:
   '@slack/bolt': ^3.12.2
   '@slack/web-api': ^6.8.1
-  chatgpt: ^5.0.10
+  chatgpt: ^5.1.1
   dotenv: ^16.0.3
+  outdent: ^0.8.0
+  promise-all-properties: ^3.0.6
   rome: ^11.0.0
   tsx: ^3.12.5
   type-fest: ^3.6.1
@@ -13,8 +15,10 @@ specifiers:
 dependencies:
   '@slack/bolt': 3.12.2
   '@slack/web-api': 6.8.1
-  chatgpt: 5.0.10
+  chatgpt: 5.1.1
   dotenv: 16.0.3
+  outdent: 0.8.0
+  promise-all-properties: 3.0.6
   zod: 3.21.4
 
 devDependencies:
@@ -640,8 +644,8 @@ packages:
       supports-color: 5.5.0
     dev: false
 
-  /chatgpt/5.0.10:
-    resolution: {integrity: sha512-R3vtPlhCapFLkDXED0Cnt1DBcOZAXygr0M5U5kbSI0Fwm4uDQmc7qoIOnr17rd8eaa0JO/UDOevJdEWvd079qA==}
+  /chatgpt/5.1.1:
+    resolution: {integrity: sha512-ml1u4/KqXdAKfaRwqE0uvRTh5JoRgosstH2LF4PpsawG7MUtIzAVaE/MMEAaV02uGbOlAH4IgKI3mDHkQ0Dmlw==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
@@ -1479,6 +1483,10 @@ packages:
       ee-first: 1.1.1
     dev: false
 
+  /outdent/0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
+    dev: false
+
   /p-cancelable/1.1.0:
     resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
     engines: {node: '>=6'}
@@ -1564,6 +1572,10 @@ packages:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
     dependencies:
       semver-compare: 1.0.0
+    dev: false
+
+  /promise-all-properties/3.0.6:
+    resolution: {integrity: sha512-A0pNGlCCtDdSePRl0ZDRBWxAETadVkv9ZxMd1ije+dkKYOV5Ji8NcjqBIzmiDYIK8ZWk5aZoNto6NhnGMhJpxQ==}
     dev: false
 
   /promise.allsettled/1.0.6:

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,13 +8,14 @@ export const createApp = ({
 	SLACK_SIGNING_SECRET,
 	SLACK_APP_TOKEN,
 	port,
-}: Env) => new App({
-  token: SLACK_BOT_TOKEN,
-  signingSecret: SLACK_SIGNING_SECRET,
-  socketMode: true,
-  appToken: SLACK_APP_TOKEN,
-  port,
-})
+}: Env) =>
+	new App({
+		token: SLACK_BOT_TOKEN,
+		signingSecret: SLACK_SIGNING_SECRET,
+		socketMode: true,
+		appToken: SLACK_APP_TOKEN,
+		port,
+	})
 
 /** app.message에 여러 함수 등록하기 */
 export const registerHooks = (app: App, hooks: readonly MessageHook[]) => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,7 +9,8 @@ const envFileSchema = z
 		SLACK_BOT_TOKEN: z.string(),
 		SLACK_SIGNING_SECRET: z.string(),
 		SLACK_APP_TOKEN: z.string(),
-		// OPENAI_API_KEY: z.string(),
+		OPENAI_API_KEY: z.string().optional(),
+    ANNOUNCEMENT_CHANNEL_ID: z.string(),
 		PORT: z.string(),
 	})
 	.strict()
@@ -33,6 +34,7 @@ export const {
 	SLACK_BOT_TOKEN,
 	SLACK_SIGNING_SECRET,
 	SLACK_APP_TOKEN,
-	// OPENAI_API_KEY,
+	OPENAI_API_KEY,
+  ANNOUNCEMENT_CHANNEL_ID,
 	port,
 } = env

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,7 +10,7 @@ const envFileSchema = z
 		SLACK_SIGNING_SECRET: z.string(),
 		SLACK_APP_TOKEN: z.string(),
 		OPENAI_API_KEY: z.string().optional(),
-    ANNOUNCEMENT_CHANNEL_ID: z.string(),
+		ANNOUNCEMENT_CHANNEL_ID: z.string(),
 		PORT: z.string(),
 	})
 	.strict()
@@ -35,6 +35,6 @@ export const {
 	SLACK_SIGNING_SECRET,
 	SLACK_APP_TOKEN,
 	OPENAI_API_KEY,
-  ANNOUNCEMENT_CHANNEL_ID,
+	ANNOUNCEMENT_CHANNEL_ID,
 	port,
 } = env

--- a/src/hooks/announcement.ts
+++ b/src/hooks/announcement.ts
@@ -1,0 +1,66 @@
+import { WebClient } from "@slack/web-api"
+import { outdent } from "outdent"
+import promiseAllProperties from "promise-all-properties"
+
+import { createHook } from "../createHook"
+import { summarize } from "../summarize"
+import { env } from "../env"
+
+const client = new WebClient(env.SLACK_BOT_TOKEN)
+
+const userDms = async () => {
+	const result = await client.conversations.list({
+		types: "im",
+		exclude_archived: true,
+		limit: 100,
+	})
+
+	const users = result
+		.channels!.map((x) => x.user)
+		.filter((x): x is string => x !== undefined)
+
+	return users
+}
+
+const makeAnnouncement =
+	({ channel, permalink, summarized }: Record<string, string>) =>
+	async (user: string) =>
+		await client.chat.postMessage({
+			channel: user,
+			text: outdent`
+      :rocket: *<#${channel}>에 <${permalink}|새 공지가 등록되었습니다!>*
+
+      ${summarized}
+    `,
+		})
+
+/** OPENAI_API_KEY가 주어지지 않으면 입력받은 공지를 그대로 출력합니다 */
+const makeSummarizer = (apiKey?: string) => {
+	if (apiKey === undefined) {
+		return async (text: string) => text.split("\n").slice(0, 3).join("\n")
+	}
+
+	return async (text: string) => (await summarize(apiKey)(text)).text
+}
+
+const summarizer = makeSummarizer(env.OPENAI_API_KEY)
+
+export const announcementHook = createHook({
+	includeChannels: [env.ANNOUNCEMENT_CHANNEL_ID],
+	fn: async ({ message: { text, ts }, event: { channel } }) => {
+		if (text === undefined) return
+
+		const { users, permalink, summarized } = await promiseAllProperties({
+			users: userDms(),
+			permalink: client.chat
+				.getPermalink({ channel, message_ts: ts })
+				.then((x) => x.permalink ?? ""),
+			summarized: summarizer(text),
+		})
+
+		console.log(`Message received: ${text}, permalink: ${permalink}`)
+
+		const announcement = makeAnnouncement({ channel, permalink, summarized })
+		await Promise.all(users.map(announcement))
+	},
+})

--- a/src/hooks/echo.ts
+++ b/src/hooks/echo.ts
@@ -3,7 +3,7 @@ import { env } from "../env"
 
 /** 받은 메시지를 그대로 메아리하는 후크 */
 export const echoHook = createHook({
-  excludeChannels: [env.ANNOUNCEMENT_CHANNEL_ID],
+	excludeChannels: [env.ANNOUNCEMENT_CHANNEL_ID],
 	fn: async ({ message: { user, text }, say }) => {
 		// 참고: https://api.slack.com/reference/surfaces/formatting#mentioning-users
 		await say(`<@${user}> said: ${text}`)

--- a/src/hooks/echo.ts
+++ b/src/hooks/echo.ts
@@ -1,9 +1,11 @@
 import { createHook } from "../createHook"
+import { env } from "../env"
 
 /** 받은 메시지를 그대로 메아리하는 후크 */
 export const echoHook = createHook({
+  excludeChannels: [env.ANNOUNCEMENT_CHANNEL_ID],
 	fn: async ({ message: { user, text }, say }) => {
-		// <>는 슬랙이 쓰는 변수 표기법, js의 `${값}` 과 비슷함
+		// 참고: https://api.slack.com/reference/surfaces/formatting#mentioning-users
 		await say(`<@${user}> said: ${text}`)
 	},
 })

--- a/src/hooks/hello.ts
+++ b/src/hooks/hello.ts
@@ -1,4 +1,5 @@
 import { createHook } from "../createHook"
+import { env } from "../env"
 
 const trigger = /안녕|반가워|hello/i
 
@@ -10,10 +11,11 @@ const trigger = /안녕|반가워|hello/i
  */
 export const helloHook = createHook({
 	trigger,
+	excludeChannels: [env.ANNOUNCEMENT_CHANNEL_ID],
 	fn: async ({ message, say }) => {
 		console.log(`Message received: ${message.text}`)
 
-		// <>는 슬랙이 쓰는 변수 표기법, js의 `${값}` 과 비슷함
+		// 참고: https://api.slack.com/reference/surfaces/formatting#mentioning-users
 		await say(`안녕안녕 ${message.user} <@${message.user}>!`)
 	},
 })

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,3 @@
-// export { announcementHook } from "./announcement"
+export { announcementHook } from "./announcement"
 export { echoHook } from "./echo"
 export { helloHook } from "./hello"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,14 @@
 import { env, port } from "./env"
 import { createApp, registerHooks } from "./app"
-import { echoHook } from "./hooks"
+import { announcementHook, echoHook } from "./hooks"
 
 const main = async () => {
 	console.log("⚡️ 앱 실행 준비 중...")
 
 	const app = createApp(env)
-	registerHooks(app, [echoHook])
+
+	registerHooks(app, [echoHook, announcementHook])
+
 	await app.start(port)
 
 	console.log("⚡️ 앱 시작!")

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1,0 +1,61 @@
+import { ChatGPTAPI, ChatMessage } from "chatgpt"
+
+const systemMessage = `you're a TL;DR-GPT.
+  1. Your job is to summarize korean text.
+  2. You must output into 3 lines of korean text.
+  3. Please keep the sentences short.
+  4. Please output in ordered list in markdown format.
+`
+
+/**
+ * 입력으로 받은 문자열을 3줄 요약해줍니다.
+ *
+ * - 사용하는데 평균 1200토큰 가량 사용됩니다.
+ * - 회당 최소 3원 이상 드니, 적정 사용량을 유지해주세요.
+ */
+type Summarize = (apiKey: string) => (text: string) => Promise<ChatMessage>
+
+/** @see {@link Summarize} */
+export const summarize: Summarize = (apiKey) => {
+	const api = new ChatGPTAPI({ apiKey })
+
+	return async (text: string) => {
+		const req = timeApi(async () => api.sendMessage(text, { systemMessage }))
+		const { result, elapsed } = await req
+
+		logUsage(result, elapsed)
+		return result
+	}
+}
+
+/** chatgpt API 요청까지 걸린 시간을 잽니다 */
+const timeApi = async (fn: () => Promise<ChatMessage>) => {
+	console.log("chatgpt :: API 요청 보내는 중...")
+	const now = performance.now()
+	const result = await fn()
+	const elapsed = performance.now() - now
+
+	return { result, elapsed }
+}
+
+/** 요청 시간, 사용 토큰 수, 예상 비용을 출력합니다 */
+const logUsage = (result: ChatMessage, elapsed: number) => {
+	const total_tokens = result.detail.usage.total_tokens as number
+	const cost = getEstimatedCost(total_tokens)
+
+	console.log(
+		`chatgpt :: ${elapsed}ms, 사용 토큰 수: ${total_tokens}, 예상 비용: ${cost}원`,
+	)
+}
+
+const DOLLAR_TO_KRW = 1319.34 // 2023-03-13 기준
+const DOLLAR_PER_1K_TOKEN = 0.002 // gpt-3.5-turbo
+const DOLLAR_PER_TOKEN = DOLLAR_PER_1K_TOKEN / 1000
+
+/**
+ * API 요청의 예상 비용을 계산합니다.
+ *
+ * @returns 원 단위의 비용
+ */
+const getEstimatedCost = (token: number): number =>
+	Math.round(token * DOLLAR_PER_TOKEN * DOLLAR_TO_KRW)


### PR DESCRIPTION
# 개요

- resolves #2 

## 내용

- chatgpt api를 사용해 공지를 요약해주는 `announcementHook` 추가
- 채널 필터로 특정 채널에서만 허가하거나 금지하는 기능 추가
- env 파일에 `ANNOUNCEMENT_CHANNEL_ID` 키 추가
- `OPENAI_API_KEY`이 없더라도 동작하게 수정
