### PR TITLE
feat: 키워드 검색시 대소문자 구별하지 않게 변경

### DIFF
--- a/src/searchKeyword.ts
+++ b/src/searchKeyword.ts
@@ -8,10 +8,14 @@ export const docSchema = z.object({
 export type Doc = z.infer<typeof docSchema>
 
 /**
- * 주어진 {@link Doc} 배열에서 `keyword`를 찾아서 `contents`를 반환합니다.
+ * 주어진 {@link Doc} 배열에서 `keyword`를 찾아서 `내용`을 반환합니다.
  */
 export const searchDocKeyword = (
-	keyword: string,
 	docs: Doc[],
-): Doc["내용"] | null =>
-	docs.find(({ 키워드 }) => 키워드.includes(keyword))?.내용 ?? null
+	keyword: string,
+): Doc["내용"] | null => {
+	const lowerKeyword = keyword.toLowerCase()
+	const result = docs.find(({ 키워드 }) => 키워드.includes(lowerKeyword))
+
+	return result?.내용 ?? null
+}


### PR DESCRIPTION
# 개요

<!--
  몇 번 이슈 해결인지 적기, 참고:
  https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

- closes #23 

## 내용

<!-- 어떤 일을 했는지 간략하게 설명하기 -->
keyword.toLowerCase()를 통해 소문자로 만들어서 대소문자 구별없이 검색하도록 변경 하였습니다.